### PR TITLE
Fix: Add Redirection State On Sign Up Button

### DIFF
--- a/public/locales/en/ai.json
+++ b/public/locales/en/ai.json
@@ -246,6 +246,7 @@
       "description": "Access partner listings"
     },
     "primaryButton": "Sign up with BaseMe",
+    "primaryButtonRedirectMessage": "Redirecting...",
     "secondaryButton": "Continue with Google",
     "disclaimer": "By signing up, you agree to our Terms and Privacy Policy."
   },

--- a/public/locales/ja/ai.json
+++ b/public/locales/ja/ai.json
@@ -246,6 +246,7 @@
       "description": "パートナー企業情報にアクセス"
     },
     "primaryButton": "BaseMeに登録する",
+    "primaryButtonRedirectMessage": "ページを移動しています...",
     "secondaryButton": "Googleで続ける",
     "disclaimer": "利用を開始することで、利用規約とプライバシーポリシーに同意したものとみなされます。"
   },

--- a/src/components/recommendations/SignupDialog.tsx
+++ b/src/components/recommendations/SignupDialog.tsx
@@ -44,6 +44,7 @@ const SignupDialog: React.FC<SignupDialogProps> = ({
   const isMobile = useIsMobile();
   const router = useRouter();
   const [isAnonymous, setIsAnonymous] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
   // Check if we're in a browser environment before accessing localStorage
   useEffect(() => {
@@ -73,6 +74,7 @@ const SignupDialog: React.FC<SignupDialogProps> = ({
 
   // Handle sign up button click with tracking
   const handleSignupClick = async () => {
+    setIsRedirecting(true);
     try {
       // Track email signup click
       await trackEmailSignupClick();
@@ -177,9 +179,12 @@ const SignupDialog: React.FC<SignupDialogProps> = ({
         <Button
           size="lg"
           onClick={handleSignupClick}
-          className="w-full p-4 font-bold border border-white text-white transition-all rounded-md sm:w-auto bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 hover:scale-105 active:scale-95"
+          disabled={isRedirecting}
+          className={`w-full p-4 font-bold border border-white text-white transition-all rounded-md sm:w-auto bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 hover:scale-105 active:scale-95 ${
+            isRedirecting ? 'opacity-60 cursor-not-allowed hover:scale-100' : ''
+          }`}
         >
-          {t('cta.primaryButton') || 'Sign up with Email'}
+          {isRedirecting ? 'Redirecting...' : t('cta.primaryButton') || 'Sign up with Email'}
         </Button>
 
         {/* <GoogleSignUpButton t={t} onClick={handleGoogleSignupClick} /> */}

--- a/src/components/recommendations/SignupDialog.tsx
+++ b/src/components/recommendations/SignupDialog.tsx
@@ -184,7 +184,9 @@ const SignupDialog: React.FC<SignupDialogProps> = ({
             isRedirecting ? 'opacity-60 cursor-not-allowed hover:scale-100' : ''
           }`}
         >
-          {isRedirecting ? 'Redirecting...' : t('cta.primaryButton') || 'Sign up with Email'}
+          {isRedirecting
+            ? t('cta.primaryButtonRedirectMessage')
+            : t('cta.primaryButton') || 'Sign up with Email'}
         </Button>
 
         {/* <GoogleSignUpButton t={t} onClick={handleGoogleSignupClick} /> */}


### PR DESCRIPTION
**Summary**
This PR implements an additional state management to track the user's redirection action between Project X and Base Me specifically correlated with the Sign Up button on the in the Sign Up Dialogue component within the Recommendation page. This was added in order to enhance UI and alleviate user confusion between cross-website navigation.

**What**
* Redirection state now tracks whether or not the user is redirecting from Project X to Base Me
* After the button is clicked, the button is disabled and a message replaces the original text with redirection text
* Text has been updated in both English and Japanese

**Why**
* To provide visual clarity for users that they are in the action of redirecting
* To prevent user confusion and excess click events to the Sign Up button

**Code Changes**
* `/src/app/components/recommendations/SignupDialog.tsx` - Added redirection state and styles dependent on state
* `ai.json` (en + ja) - Localized strings for new UI text
